### PR TITLE
Allows keycloak 12 to be installed on Ubuntu 20

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,5 +18,9 @@ keycloak_mysql_user: keycloak
 keycloak_mysql_password: keycloak
 keycloak_mysql_database: keycloak
 keycloak_mysql_port: 3306
+keycloak_python_lxml: python-lxml
+keycloak_srv_namespace: 'urn:jboss:domain:10.0'
+keycloak_sub_namespace: 'urn:jboss:domain:datasources:5.0'
+keycloak_jboss_timeout: "300"
 
 ...

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -10,7 +10,7 @@
     cache_valid_time: 3600
   vars:
     packages:
-    - python-lxml
+    - "{{ keycloak_python_lxml }}"
     - unzip
 
 - name: get mysql connector
@@ -56,8 +56,8 @@
         name: "mysql"
         module: "com.mysql"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -66,8 +66,8 @@
     add_children:
     - driver-class: "com.mysql.cj.jdbc.Driver"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -75,8 +75,8 @@
     xpath: /srv:server/srv:profile/sub:subsystem/sub:datasources/sub:datasource[@jndi-name="java:jboss/datasources/KeycloakDS"]/@use-java-context
     state: absent
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -84,8 +84,8 @@
     xpath: /srv:server/srv:profile/sub:subsystem/sub:datasources/sub:datasource[@jndi-name="java:jboss/datasources/KeycloakDS"]/sub:connection-url
     value: "jdbc:mysql://{{ keycloak_mysql_host }}:{{ keycloak_mysql_port }}/{{ keycloak_mysql_database }}?useSSL=false&characterEncoding=UTF-8"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -93,8 +93,8 @@
     xpath: /srv:server/srv:profile/sub:subsystem/sub:datasources/sub:datasource[@jndi-name="java:jboss/datasources/KeycloakDS"]/sub:driver
     value: "mysql"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -102,8 +102,8 @@
     xpath: /srv:server/srv:profile/sub:subsystem/sub:datasources/sub:datasource[@jndi-name="java:jboss/datasources/KeycloakDS"]/sub:security/sub:user-name
     value: "{{ keycloak_mysql_user }}"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -111,8 +111,8 @@
     xpath: /srv:server/srv:profile/sub:subsystem/sub:datasources/sub:datasource[@jndi-name="java:jboss/datasources/KeycloakDS"]/sub:security/sub:password
     value: "{{ keycloak_mysql_password }}"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -122,8 +122,8 @@
     - pool
     - validation
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -133,8 +133,8 @@
     - min-pool-size: "5"
     - max-pool-size: "15"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
 
 - name: modify standalone.xml
   xml:
@@ -147,7 +147,17 @@
     - exception-sorter:
         class-name: "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"
     namespaces:
-      srv: urn:jboss:domain:10.0
-      sub: urn:jboss:domain:datasources:5.0
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: "{{ keycloak_sub_namespace }}"
+
+- name: modify standalone.xml
+  xml:
+    path: "{{ keycloak_jboss_home }}/standalone/configuration/standalone.xml"
+    xpath: /srv:server/srv:profile/sub:subsystem/sub:coordinator-environment
+    attribute: default-timeout
+    value: "{{ keycloak_jboss_timeout }}"
+    namespaces:
+      srv: "{{ keycloak_srv_namespace }}"
+      sub: urn:jboss:domain:transactions:5.0
 
 ...

--- a/templates/keycloak.service.j2
+++ b/templates/keycloak.service.j2
@@ -7,7 +7,7 @@ Type=idle
 Environment=JBOSS_HOME={{ keycloak_jboss_home }} JBOSS_LOG_DIR={{ keycloak_log_dir }} "JAVA_OPTS=-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
 User=keycloak
 Group=keycloak
-ExecStart=/bin/bash -c "{{ keycloak_jboss_home }}/bin/standalone.sh --server-config=standalone.xml -Djboss.bind.address={{ keycloak_bind_address }} -Djboss.bind.address.management={{ keycloak_bind_address }} -Djboss.http.port={{ keycloak_bind_port }}"
+ExecStart=/bin/bash -c "{{ keycloak_jboss_home }}/bin/standalone.sh --server-config=standalone.xml -Djboss.bind.address={{ keycloak_bind_address }} -Djboss.bind.address.management={{ keycloak_bind_address }} -Djboss.http.port={{ keycloak_bind_port }} -Djboss.as.management.blocking.timeout={{ keycloak_jboss_timeout }}"
 TimeoutStartSec=600
 TimeoutStopSec=600
 


### PR DESCRIPTION
- Allows a configurable timeout for jboss start as it took over 20 minutes on a test install. (This excessive startup time was MySQL operations running to alter tables etc)
- Allows configurable node mapping for standalone.xml as different versions of Keycloak use different namespaces
- Ubuntu 20 uses python3-lxml rather than python-xml

My host vars were:
```
keycloak_version: 12.0.1
keycloak_archive: keycloak-{{ keycloak_version }}.tar.gz
keycloak_url: https://github.com/keycloak/keycloak/releases/download/{{ keycloak_version }}/{{ keycloak_archive }}
keycloak_bind_address: "127.0.0.1"
keycloak_admin_username: "admin"
keycloak_admin_password: "snipped"
keycloak_create_admin: True
keycloak_mysql: True
keycloak_mysql_password: snipped
keycloak_python_lxml: python3-lxml
keycloak_srv_namespace: 'urn:jboss:domain:14.0'
keycloak_sub_namespace: 'urn:jboss:domain:datasources:6.0'
keycloak_jboss_timeout: "3600"
```

N.B. `keycloak_jboss_timeout` must be quoted as `lxml.etree._setAttributeValue` cannot use ints to alter attribute values in the XML.